### PR TITLE
[Feat] Track Sessions: Performance Tuning

### DIFF
--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -180,6 +180,10 @@ a:visited {
   margin-left: auto;
 }
 
+.footer-item a:visited {
+  color: var(--link-color);
+}
+
 nav {
   display: flex;
   align-items: stretch;


### PR DESCRIPTION
Upon testing and feedback, Track Sessions was not very performant on slower storage (e.g. `Longhorn` on `k3s`) during write operations to the SQLite database. This PR moves much of the SQLite write logic to async operations using `setTimeout()`, and employs a better backoff algorithm for extra page lookups, which help greatly reduce perceived load times. Furthermore, logging is slightly improved. Finally, a CSS tweak was made to the `footer-item` class to force links to use the standard link color always instead of reverting to the visited color after being clicked.

Track Sessions Performance Logging in the footer:
![Screenshot 2025-02-04 at 12 36 47 PM](https://github.com/user-attachments/assets/d8ae0fa3-d257-4486-a21a-9dad2e119903)
