### PR TITLE
[Feat] Index Render Extraction & Track Session Views

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,8 @@ It is better than [`old-reddit`](https://old.reddit.com) because:
 - minimal use of client-side javascript
 - card and compact views
 - pagination
-- allows automatic collapsing of `automod` comments
+- allows automatic collapsing of `u/AutoModerator` comments
+- optional reduction of duplicate posts during a session
 - multireddit support
 - crosspost support
 - extensible support for popular 3rd-party media (imgur images and galleries, xkcd, etc.)

--- a/src/mixins/header.pug
+++ b/src/mixins/header.pug
@@ -3,7 +3,7 @@ mixin header(user)
   - var sortQuery = 'sort=' + (prefs ? prefs.sort : (query ? (query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot') : 'hot'))
   div.header
     div.header-item
-      a(href=`/?${viewQuery}`) home
+      a(href=`/home?${viewQuery}`) home
     div.header-item
       a(href=`/r/all?${viewQuery}`) all
     div.header-item

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -952,7 +952,7 @@ select {
   border-left-color: var(--msg-info);
 }
 
-.message.warning {
+.message.caution {
   border-left-color: var(--msg-caution);
 }
 
@@ -973,7 +973,7 @@ select {
   color: var(--msg-info);
 }
 
-.message.warning > .message-title {
+.message.caution > .message-title {
   color: var(--msg-caution);
 }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -15,6 +15,12 @@ const E = extlinks.ExtLinks;
 
 // GET /
 router.get("/", authenticateToken, async (req, res) => {
+	const qs = req.query ? ('?' + new URLSearchParams(req.query).toString()) : '';
+	res.redirect(`/home${qs}`);
+});
+
+// GET /home
+router.get("/home", authenticateToken, async (req, res) => {
 	const subs = db
 		.query("SELECT * FROM subscriptions WHERE user_id = $id")
 		.all({ id: req.user.id });
@@ -25,324 +31,28 @@ router.get("/", authenticateToken, async (req, res) => {
 		res.redirect(`/r/all${qs}`);
 	} else {
 		const p = subs.map((s) => s.subreddit).join("+");
-		res.redirect(`/r/${p}${qs}`);
+		renderIndex(p, req, res);
 	}
 });
 
 // GET /r/:id
 router.get("/r/:subreddit", authenticateToken, async (req, res) => {
 	const subreddit = req.params.subreddit;
-	const multireddit = req.query.lurker_multi;
-	const isMulti = subreddit.includes("+") || multireddit;
-	const query = req.query ? req.query : {};
 
-	const prefs = get_user_prefs(req.user.id);
-
-	if (!query.sort) {
-		query.sort = prefs.sort;
-	}
-	if (!query.view) {
-		query.view = prefs.view;
-	}
-
-	let isSubbed = false;
-	if (!isMulti) {
-		isSubbed =
-			db
-				.query(
-					"SELECT * FROM subscriptions WHERE user_id = $id AND subreddit = $subreddit",
-				)
-				.get({ id: req.user.id, subreddit }) !== null;
-	}
-	const postsReq = G.getSubmissions(query.sort, `${subreddit}`, query);
-	const aboutReq = G.getSubreddit(`${subreddit}`);
-
-	// Track Sessions Performance logging
-	const perfEvents = [];
-	const perfStartTime = performance.now();
-	var perfEventTime = performance.now();
-
-	const [posts, about] = await Promise.all([postsReq, aboutReq]);
-
-	if (posts && prefs.trackSessions) {
-		// Capture the initial load event
-		perfEvents.push({
-			description: `Retrieved page of ${posts.posts.length} posts`,
-			elapsed: performance.now() - perfEventTime,
-		});
-
-		perfEventTime = performance.now();
-		// Reuse or create a new session
-		let session = 
-			db.query(`
-				SELECT id, query 
-				FROM sessions 
-				WHERE user_id = $user_id AND subreddit = $subreddit
-			`).get({ user_id: req.user.id, subreddit: subreddit});
-
-		perfEvents.push({
-			description: `${session ? 'Retrieved' : 'Could not find'} session`,
-			elapsed: performance.now() - perfEventTime,
-		});
-
-		// Create a new session if necessary
-		if (!session || !req.query.after) {
-			// Remove the old session and views
-			if (session) {
-				perfEventTime = performance.now();
-				/* Explicitly pass the session_id since it will have changed
-				 * by the time this is executed
-				 */
-				setTimeout((session_id) => {
-					// Remove prior views
-					db.query(`
-						DELETE FROM views
-						WHERE session_id = $session_id
-					`).run({ session_id: session_id });
-
-					// Remove prior session
-					db.query(`
-						DELETE FROM sessions
-						WHERE id = $session_id
-					`).run({ session_id: session_id });
-				}, 0, session.id);
-
-				perfEvents.push({
-					description: 'Session outdated; sheduled delete of old session and views',
-					elapsed: performance.now() - perfEventTime,
-				});
-			}
-
-			perfEventTime = performance.now();
-			// Create a new session for this subreddit and query
-			session = 
-				db.query(`
-					INSERT INTO sessions (user_id, subreddit, query)
-					VALUES ($user_id, $subreddit, $query)
-					RETURNING id, query
-				`).get({ user_id: req.user.id, subreddit: subreddit, query: posts.after });
-
-			perfEvents.push({
-				description: 'Created new session',
-				elapsed: performance.now() - perfEventTime,
-			});
-		}
-
-		// If we're on a different page,
-		if (session.query != req.query.after) {
-			perfEventTime = performance.now();
-			// Get the views for this session
-			let views = 
-				db.query(`
-					SELECT post_id FROM views WHERE session_id = $session_id
-				`).all({ session_id: session.id });
-
-			perfEvents.push({
-				description: `Retrieved ${views.length} views from session`,
-				elapsed: performance.now() - perfEventTime,
-			});
-	
-			perfEventTime = performance.now();
-			// Remove any previously-seen posts from this session
-			let removedPosts = 0;
-			let postsToRemove = new Set(views.map(view => view.post_id))
-				.intersection(new Set(posts.posts.map(post => post.data.id)));
-
-			perfEvents.push({
-				description: `Got Set of ${postsToRemove.size || 0} duplicate post${(postsToRemove.size || 0) != 1 ? 's' : ''} to remove`,
-				elapsed: performance.now() - perfEventTime,
-			});
-				
-			perfEventTime = performance.now();
-			
-			for (const id of postsToRemove) {
-				let index = posts.posts.findIndex((post) => post.data.id == id);
-				if (index >= 0) {
-					posts.posts.splice(index, 1);
-					removedPosts++;
-				}
-			}
-
-			perfEvents.push({
-				description: `Removed ${removedPosts} duplicate post${removedPosts != 1 ? 's' : ''}`,
-				elapsed: performance.now() - perfEventTime,
-			});
-	
-			// Get more posts
-			var perfLoopCounter = 0;
-			var perfTotalRemoved = removedPosts;
-			const perfStartLoopTime = performance.now();
-			while (removedPosts > 0) {
-				perfLoopCounter++;
-				var perfLoopRemoved = 0;
-
-				perfEventTime = performance.now();
-				// Get up to double the number of removed posts, depending on how many we need
-				let bufferFactor = (removedPosts > 10 ? 1.25 : removedPosts > 5 ? 1.5 : 2);
-				let bufferLimit = Math.round(removedPosts * bufferFactor);
-
-				const postsReq = G.getSubmissions(query.sort, `${subreddit}`, { ...query, after: posts.after, limit: bufferLimit });
-				const [extraPosts] = await Promise.all([postsReq]);
-			
-				// If we fail to retrieve any more posts, give up entirely and render the view
-				if (!extraPosts) {
-					break;
-				}
-
-				perfEvents.push({
-					description: `[Loop ${perfLoopCounter}] Retrieved ${extraPosts.posts.length} extra post${extraPosts.posts.length != 1 ? 's' : ''}`,
-					elapsed: performance.now() - perfEventTime,
-				});
-
-				perfEventTime = performance.now();
-				// Remove any previously-seen posts from this session (including those we just pulled for this view)
-				let postsToRemove = new Set(views.map(view => view.post_id))
-					.union(new Set(posts.posts.map(post => post.data.id)))
-					.intersection(new Set(extraPosts.posts.map(post => post.data.id)));
-
-				perfEvents.push({
-					description: `[Loop ${perfLoopCounter}] Got Set of ${postsToRemove.size || 0} duplicate extra posts to remove`,
-					elapsed: performance.now() - perfEventTime,
-				});
-			
-				perfEventTime = performance.now();
-				for (const id of postsToRemove) {
-					let index = extraPosts.posts.findIndex((post) => post.data.id == id);
-					if (index >= 0) {
-						extraPosts.posts.splice(index, 1);
-						perfLoopRemoved++;
-					}
-				}
-
-				perfEvents.push({
-					description: `[Loop ${perfLoopCounter}] Removed ${perfLoopRemoved} duplicate extra posts`,
-					elapsed: performance.now() - perfEventTime,
-				});
-			
-				perfEventTime = performance.now();
-				// Push these onto the end of the new posts, up to `removedPosts` times
-				var c = 0;
-				for (const post of extraPosts.posts) {
-					if (removedPosts > 0) {
-						posts.posts.push(post);
-						// Update the `after` value
-						posts.after = `${post.kind}_${post.data.id}`;
-						// Decrement removedPosts counter
-						removedPosts--;
-						// Increment counter
-						c++;
-					}
-					else {
-						break;
-					}
-				}
-				
-				perfEvents.push({
-					description:  `[Loop ${perfLoopCounter}] Pushed ${c} extra post${c != 1 ? 's' : ''}, need ${removedPosts} more post${removedPosts != 1 ? 's' : ''}`,
-					elapsed: performance.now() - perfEventTime,
-				});
-
-				perfTotalRemoved += perfLoopRemoved;
-			}
-
-			if (perfLoopCounter > 0) {
-				perfEvents.push({
-					description: `Finished ${perfLoopCounter} loop${perfLoopCounter != 1 ? 's': ''}`,
-					elapsed: performance.now() - perfStartLoopTime,
-				});
-			}
-
-			perfEventTime = performance.now();
-			// Update the session and insert the resulting set of views asynchronously
-			setTimeout(() => {
-				db.query(`
-					UPDATE sessions
-					SET query = $query
-					WHERE id = $session_id
-				`).run({ session_id: session.id, query: req.query.after });
-
-				// Build the INSERT
-				var q = 'INSERT INTO views (session_id, post_id) VALUES ';
-				var p = {
-					session_id: session.id,
-				};
-				var i = 0;
-				posts.posts.forEach((post) => {
-					q += `($session_id, $post_id_${i}), `;
-					p[`post_id_${i}`] = post.data.id;
-					i++;
-				});
-				db.query(q.trimEnd().replace(/,$/g, '')).run(p);
-			});
-
-			perfEvents.push({
-				description: 'Scheduled update for session and views',
-				elapsed: performance.now() - perfEventTime,
-			});
-		}
-
-		perfEvents.push({
-			description: `Replaced ${perfTotalRemoved || 0} duplicate post${(perfTotalRemoved || 0) != 1 ? 's': ''}`,
-			elapsed: performance.now() - perfStartTime,
-		});
-	}
-
-	if (query.view == 'card' && posts && posts.posts) {
-		posts.posts.forEach(unescape_selftext);
-		posts.posts.forEach(unescape_media_embed);
-
-		var extPromises = [];
-		for (const post of posts.posts) {
-			if (post.data.post_hint == 'link') {
-				extPromises.push(E.resolveExternalLinks(post.data));
-			} else {
-				extPromises.push(null);
-			}
-		}
-		const extResults = await Promise.all(extPromises);
-		extResults.map((extData, i) => {
-			if (extData) {
-				E.updatePost(posts.posts[i].data, extData);
-			}
-		});
-	}
-
-	res.locals = {
-		require_he: require("he"),
-	};
-
-	res.render("index", {
-		subreddit,
-		multireddit,
-		posts,
-		about,
-		query,
-		isMulti,
-		user: req.user,
-		isSubbed,
-		currentUrl: req.url,
-		perfEvents,
-	});
+	renderIndex(subreddit, req, res);
 });
 
 // GET /m/:id
 router.get("/m/:multireddit", authenticateToken, async(req, res) => {
-	var multireddit = req.params.multireddit;
-
+	const multireddit = req.params.multireddit;
 	const multi_sub = db
 		.query("SELECT * FROM multireddits WHERE user_id = $id AND multireddit = $multireddit COLLATE NOCASE")
 		.all({ id: req.user.id, multireddit: multireddit });
-
-	const subs = multi_sub
-		.map((s) => s.subreddit).join("+");
+	const subs = multi_sub.map((s) => s.subreddit).join("+");
 
 	if (multi_sub.length > 0) {
-		multireddit = multi_sub[0].multireddit;
-
-		req.query.lurker_multi = multireddit;
-		const qs = req.query ? ('?' + new URLSearchParams(req.query).toString()) : '';
-
-		res.redirect(`/r/${subs}${qs}`);
+		req.query.lurker_multi = multi_sub[0].multireddit;
+		renderIndex(subs, req, res);
 	}
 	else {
 		const qs = req.query ? ('?' + new URLSearchParams(req.query).toString()) : '';
@@ -815,6 +525,318 @@ router.post("/multi-remove", authenticateToken, async (req, res) => {
 });
 
 module.exports = router;
+
+async function renderIndex(subreddit, req, res) {
+	const multireddit = req.query.lurker_multi;
+	const isMulti = subreddit.includes("+") || multireddit;
+	const query = req.query ? req.query : {};
+
+	const prefs = get_user_prefs(req.user.id);
+
+	if (!query.sort) {
+		query.sort = prefs.sort;
+	}
+	if (!query.view) {
+		query.view = prefs.view;
+	}
+
+	let isSubbed = false;
+	if (!isMulti) {
+		isSubbed =
+			db
+				.query(
+					"SELECT * FROM subscriptions WHERE user_id = $id AND subreddit = $subreddit",
+				)
+				.get({ id: req.user.id, subreddit }) !== null;
+	}
+	const postsReq = G.getSubmissions(query.sort, `${subreddit}`, query);
+	const aboutReq = G.getSubreddit(`${subreddit}`);
+
+	// Track Sessions Performance logging
+	const perfEvents = [];
+	const perfStartTime = performance.now();
+	var perfEventTime = performance.now();
+
+	const [posts, about] = await Promise.all([postsReq, aboutReq]);
+
+	if (about && about.public_description) {
+		about.public_description = he.decode(about.public_description);
+	}
+
+	if (posts && prefs.trackSessions) {		
+		// Capture the initial load event
+		perfEvents.push({
+			description: `Retrieved page of ${posts.posts.length} posts`,
+			elapsed: performance.now() - perfEventTime,
+		});
+
+		perfEventTime = performance.now();
+		// Reuse or create a new session
+		let session = 
+			db.query(`
+				SELECT id, query 
+				FROM sessions 
+				WHERE user_id = $user_id AND subreddit = $subreddit
+				ORDER BY id DESC
+				LIMIT 1 OFFSET 0
+			`).get({ user_id: req.user.id, subreddit: subreddit});
+
+		perfEvents.push({
+			description: `${session ? 'Retrieved' : 'Did not find'} session`,
+			elapsed: performance.now() - perfEventTime,
+		});
+
+		// Create a new session if necessary
+		if (!session || !req.query.after) {
+			// Remove the old session and views
+			if (session) {
+				perfEventTime = performance.now();
+				//Explicitly pass the session_id since it will have changed
+				//by the time this is executed
+				setTimeout(() => {
+					// Remove prior session(s)
+					// Which will cascade delete views
+					db.query(`
+						DELETE FROM sessions
+						WHERE id IN (
+							SELECT id FROM sessions
+							WHERE user_id = $user_id
+							ORDER BY id DESC
+							LIMIT -1 OFFSET 1
+						)
+					`).run({ user_id: req.user.id });
+				});
+
+				perfEvents.push({
+					description: 'Session outdated; scheduled for removal',
+					elapsed: performance.now() - perfEventTime,
+				});
+			}
+
+			perfEventTime = performance.now();
+			// Create a new session for this subreddit and query
+			session = 
+				db.query(`
+					INSERT INTO sessions (user_id, subreddit, query)
+					VALUES ($user_id, $subreddit, $query)
+					RETURNING id, query
+				`).get({ user_id: req.user.id, subreddit: subreddit, query: posts.after });
+
+			perfEvents.push({
+				description: 'Created new session',
+				elapsed: performance.now() - perfEventTime,
+			});
+		}
+
+		// If we're on a different page,
+		if (session.query != req.query.after) {
+			perfEventTime = performance.now();
+			// Get the views for this session
+			let views = 
+				db.query(`
+					SELECT post_id FROM views WHERE session_id = $session_id
+				`).all({ session_id: session.id });
+
+			perfEvents.push({
+				description: `Retrieved ${views.length} views from session`,
+				elapsed: performance.now() - perfEventTime,
+			});
+	
+			perfEventTime = performance.now();
+			// Remove any previously-seen posts from this session
+			let removedPosts = 0;
+			let postsToRemove = new Set(views.map(view => view.post_id))
+				.intersection(new Set(posts.posts.map(post => post.data.id)));
+
+			perfEvents.push({
+				description: `Got Set of ${postsToRemove.size || 0} duplicate post${(postsToRemove.size || 0) != 1 ? 's' : ''} to remove`,
+				elapsed: performance.now() - perfEventTime,
+			});
+				
+			perfEventTime = performance.now();
+			
+			for (const id of postsToRemove) {
+				let index = posts.posts.findIndex((post) => post.data.id == id);
+				if (index >= 0) {
+					posts.posts.splice(index, 1);
+					removedPosts++;
+				}
+			}
+
+			perfEvents.push({
+				description: `Removed ${removedPosts} duplicate post${removedPosts != 1 ? 's' : ''}`,
+				elapsed: performance.now() - perfEventTime,
+			});
+	
+			// Get more posts
+			var perfLoopCounter = 0;
+			var perfTotalRemoved = removedPosts;
+			const perfStartLoopTime = performance.now();
+			while (removedPosts > 0) {
+				perfLoopCounter++;
+				var perfLoopRemoved = 0;
+
+				perfEventTime = performance.now();
+				// Get up to double the number of removed posts, depending on how many we need
+				let bufferFactor = (removedPosts > 10 ? 1.25 : removedPosts > 5 ? 1.5 : 2);
+				let bufferLimit = Math.round(removedPosts * bufferFactor);
+
+				const postsReq = G.getSubmissions(query.sort, `${subreddit}`, { ...query, after: posts.after, limit: bufferLimit });
+				const [extraPosts] = await Promise.all([postsReq]);
+			
+				// If we fail to retrieve any more posts, give up entirely and render the view
+				if (!extraPosts) {
+					break;
+				}
+
+				perfEvents.push({
+					description: `[Loop ${perfLoopCounter}] Retrieved ${extraPosts.posts.length} extra post${extraPosts.posts.length != 1 ? 's' : ''}`,
+					elapsed: performance.now() - perfEventTime,
+				});
+
+				perfEventTime = performance.now();
+				// Remove any previously-seen posts from this session (including those we just pulled for this view)
+				let postsToRemove = new Set(views.map(view => view.post_id))
+					.union(new Set(posts.posts.map(post => post.data.id)))
+					.intersection(new Set(extraPosts.posts.map(post => post.data.id)));
+
+				perfEvents.push({
+					description: `[Loop ${perfLoopCounter}] Got Set of ${postsToRemove.size || 0} duplicate extra posts to remove`,
+					elapsed: performance.now() - perfEventTime,
+				});
+			
+				perfEventTime = performance.now();
+				for (const id of postsToRemove) {
+					let index = extraPosts.posts.findIndex((post) => post.data.id == id);
+					if (index >= 0) {
+						extraPosts.posts.splice(index, 1);
+						perfLoopRemoved++;
+					}
+				}
+
+				perfEvents.push({
+					description: `[Loop ${perfLoopCounter}] Removed ${perfLoopRemoved} duplicate extra posts`,
+					elapsed: performance.now() - perfEventTime,
+				});
+			
+				perfEventTime = performance.now();
+				// Push these onto the end of the new posts, up to `removedPosts` times
+				var c = 0;
+				for (const post of extraPosts.posts) {
+					if (removedPosts > 0) {
+						posts.posts.push(post);
+						// Update the `after` value
+						posts.after = `${post.kind}_${post.data.id}`;
+						// Decrement removedPosts counter
+						removedPosts--;
+						// Increment counter
+						c++;
+					}
+					else {
+						break;
+					}
+				}
+				
+				perfEvents.push({
+					description:  `[Loop ${perfLoopCounter}] Pushed ${c} extra post${c != 1 ? 's' : ''}, need ${removedPosts} more post${removedPosts != 1 ? 's' : ''}`,
+					elapsed: performance.now() - perfEventTime,
+				});
+
+				perfTotalRemoved += perfLoopRemoved;
+			}
+
+			if (perfLoopCounter > 0) {
+				perfEvents.push({
+					description: `Finished ${perfLoopCounter} loop${perfLoopCounter != 1 ? 's': ''}`,
+					elapsed: performance.now() - perfStartLoopTime,
+				});
+			}
+
+			perfEventTime = performance.now();
+			// Update the session and insert the resulting set of views asynchronously
+			setTimeout(() => {
+				db.query(`
+					UPDATE sessions
+					SET query = $query
+					WHERE id = $session_id
+				`).run({ session_id: session.id, query: req.query.after });
+
+				// Build the INSERT
+				var q = 'INSERT INTO views (session_id, post_id) VALUES ';
+				var p = {
+					session_id: session.id,
+				};
+				var i = 0;
+				posts.posts.forEach((post) => {
+					q += `($session_id, $post_id_${i}), `;
+					p[`post_id_${i}`] = post.data.id;
+					i++;
+				});
+				db.query(q.trimEnd().replace(/,$/g, '')).run(p);
+			});
+
+			perfEvents.push({
+				description: 'Scheduled update for session and views',
+				elapsed: performance.now() - perfEventTime,
+			});
+		}
+
+		perfEventTime = performance.now();
+		// Schedule an optimize for long-running connnections: https://www.sqlite.org/pragma.html#pragma_optimize
+		setTimeout(() => {
+			db.run(`
+				PRAGMA optimize;
+			`);
+		});
+
+		perfEvents.push({
+			description: `Scheduled SQLite optimize`,
+			elapsed: performance.now() - perfEventTime,
+		});
+
+		perfEvents.push({
+			description: `Replaced ${perfTotalRemoved || 0} duplicate post${(perfTotalRemoved || 0) != 1 ? 's': ''}`,
+			elapsed: performance.now() - perfStartTime,
+		});
+	}
+
+	if (query.view == 'card' && posts && posts.posts) {
+		posts.posts.forEach(unescape_selftext);
+		posts.posts.forEach(unescape_media_embed);
+
+		var extPromises = [];
+		for (const post of posts.posts) {
+			if (post.data.post_hint == 'link') {
+				extPromises.push(E.resolveExternalLinks(post.data));
+			} else {
+				extPromises.push(null);
+			}
+		}
+		const extResults = await Promise.all(extPromises);
+		extResults.map((extData, i) => {
+			if (extData) {
+				E.updatePost(posts.posts[i].data, extData);
+			}
+		});
+	}
+
+	res.locals = {
+		require_he: require("he"),
+	};
+
+	res.render("index", {
+		subreddit,
+		multireddit,
+		posts,
+		about,
+		query,
+		isMulti,
+		user: req.user,
+		isSubbed,
+		currentUrl: req.url,
+		perfEvents,
+	});
+}
 
 function get_user_prefs(user_id) {
 	const prefs = db.query(`

--- a/src/views/dashboard.pug
+++ b/src/views/dashboard.pug
@@ -58,24 +58,30 @@ html
                 p Automaticaly collapses comments made by &nbsp;
                   code u/AutoModerator
                   | . 
+          div.preference
+            input(type="checkbox" id="pref_trackSessions" checked=prefs.trackSessions!==0 onclick=`togglePref('trackSessions')`)
+            label(for="pref_trackSessions") Track Session Views
+            div.message.info
+              p.message-title Note
+              p May increase page load times, typically by ~0.5s to ~1s
+            div.message
+              p Limits duplicate posts by storing post ids already seen during the session, removing them from the feed on subsequent pages, and loading enough new posts to make up the difference.
+              p A new session is started when you naviate to 
+                a /home
+                | ,  
+                a /all
+                | , a subreddit, or a multireddit, and continues as long as you stay on the same subreddit or multireddit by clicking 
+                a next ->
+                | . 
 
-          details.preference
+          //-details.preference
             summary(style="color: var(--msg-caution);") Experimental - Proceed with caution
             div.preference-group
               div.preference
-                input(type="checkbox" id="pref_trackSessions" checked=prefs.trackSessions!==0 onclick=`togglePref('trackSessions')`)
-                label(for="pref_trackSessions") Track Session Views
-                div.message.warning
-                  p.message-title Warning
-                  p May increase page load times significantly after extended usage
-                div.message
-                  p Limits duplicate posts by storing post ids already seen during the session, removing them from the feed on subsequent pages, and loading enough new posts to make up the difference. A session is started when you first click &nbsp;
-                    code next ⟶
-                    | &nbsp; while browsing, and ends when you navigate to 
-                    code /home
-                    | ,  
-                    code /all
-                    | , or another subreddit, multireddit, etc.
+                input(type="checkbox" id="pref_trackSessionsDebug" checked=prefs.trackSessionsDebug!==0 onclick=`togglePref('trackSessionsDebug')`)
+                label(for="pref_trackSessionsDebug") Track Session Views Performance / Debug
+                div.message.caution
+                    p Shows Track Session Views performance and debug info in the footer
 
         if isAdmin
           h2 invites

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -77,7 +77,7 @@ html
 
         if perfEvents || posts.after
           div.footer
-            if perfEvents
+            //-if perfEvents
               div.footer-item
                 details(style="color: var(--text-color-muted); font-size: smaller;")
                   summary

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -4,6 +4,7 @@ include ../mixins/head
 include ../utils
   - var viewQuery = query && query.view ? query.view : 'compact'
   - var sortQuery = query && query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot'
+  - var currentPath = new URL(`http://lurker${currentUrl}`).pathname;
 doctype html
 html
   +head("home")
@@ -22,7 +23,7 @@ html
               a(href=`${multilink}?sort=${sortQuery}&view=${viewQuery}`)
                 | #{multititle}
             else
-              a(href=`/r/${subreddit}?sort=${sortQuery}&view=${viewQuery}`)
+              a(href=`${currentPath}?sort=${sortQuery}&view=${viewQuery}`)
                 | r/#{subreddit}
           if !isMulti
             div#button-container
@@ -35,12 +36,6 @@ html
               a.button(href=`/multi-edit/${multireddit}?sort=${sortQuery}&view=${viewQuery}`) edit
         if about && !isMulti
           div.about #{about.public_description}
-        //-else 
-          div.about 
-            | consider donating to&nbsp;
-            a(href="https://donate.stripe.com/dR62bTaZH1295Da4gg") oppiliappan
-            |, author of lurker
-        if about && !isMulti
           div.info-container
             p
               | #{fmtnum(about.accounts_active)} active
@@ -51,30 +46,30 @@ html
           summary.preference sorting by #{query.sort + (query.t?' '+query.t:'')}, #{viewQuery} view
           div.pref-opts
             div
-              a(href=`/r/${subreddit}?sort=hot&view=${viewQuery}` onclick=`setPref('sort', 'hot')` id=`pref_sort_hot`) hot
+              a(href=`${currentPath}?sort=hot&view=${viewQuery}` onclick=`setPref('sort', 'hot')` id=`pref_sort_hot`) hot
             div
-              a(href=`/r/${subreddit}?sort=best&view=${viewQuery}` onclick=`setPref('sort', 'best')` id=`pref_sort_best`) best
+              a(href=`${currentPath}?sort=best&view=${viewQuery}` onclick=`setPref('sort', 'best')` id=`pref_sort_best`) best
             div
-              a(href=`/r/${subreddit}?sort=new&view=${viewQuery}` onclick=`setPref('sort', 'new')` id=`pref_sort_new`) new
+              a(href=`${currentPath}?sort=new&view=${viewQuery}` onclick=`setPref('sort', 'new')` id=`pref_sort_new`) new
             div
-              a(href=`/r/${subreddit}?sort=rising&view=${viewQuery}` onclick=`setPref('sort', 'rising')` id=`pref_sort_rising`) rising
+              a(href=`${currentPath}?sort=rising&view=${viewQuery}` onclick=`setPref('sort', 'rising')` id=`pref_sort_rising`) rising
             div
-              a(href=`/r/${subreddit}?sort=top&view=${viewQuery}` onclick=`setPref('sort', 'top')` id=`pref_sort_top`) top
+              a(href=`${currentPath}?sort=top&view=${viewQuery}` onclick=`setPref('sort', 'top')` id=`pref_sort_top`) top
             div
-              a(href=`/r/${subreddit}?sort=top&t=day&view=${viewQuery}` onclick=`setPref('sort', 'top&t=day')` id=`pref_sort_top_day`) top day
+              a(href=`${currentPath}?sort=top&t=day&view=${viewQuery}` onclick=`setPref('sort', 'top&t=day')` id=`pref_sort_top_day`) top day
             div
-              a(href=`/r/${subreddit}?sort=top&t=week&view=${viewQuery}` onclick=`setPref('sort', 'top&t=week')` id=`pref_sort_top_week`) top week
+              a(href=`${currentPath}?sort=top&t=week&view=${viewQuery}` onclick=`setPref('sort', 'top&t=week')` id=`pref_sort_top_week`) top week
             div
-              a(href=`/r/${subreddit}?sort=top&t=month&view=${viewQuery}` onclick=`setPref('sort', 'top&t=month')` id=`pref_sort_top_month`) top month
+              a(href=`${currentPath}?sort=top&t=month&view=${viewQuery}` onclick=`setPref('sort', 'top&t=month')` id=`pref_sort_top_month`) top month
             div
-              a(href=`/r/${subreddit}?sort=top&t=year&view=${viewQuery}` onclick=`setPref('sort', 'top&t=year')` id=`pref_sort_top_year`) top year
+              a(href=`${currentPath}?sort=top&t=year&view=${viewQuery}` onclick=`setPref('sort', 'top&t=year')` id=`pref_sort_top_year`) top year
             div
-              a(href=`/r/${subreddit}?sort=top&t=all&view=${viewQuery}` onclick=`setPref('sort', 'top&t=all')` id=`pref_sort_top_all`) top all
+              a(href=`${currentPath}?sort=top&t=all&view=${viewQuery}` onclick=`setPref('sort', 'top&t=all')` id=`pref_sort_top_all`) top all
           div.pref-opts.view-opts
             div
-              a(href=`/r/${subreddit}?sort=${sortQuery}&view=card` onclick=`setPref('view', 'card')` id=`pref_view_card`) card
+              a(href=`${currentPath}?sort=${sortQuery}&view=card` onclick=`setPref('view', 'card')` id=`pref_view_card`) card
             div
-              a(href=`/r/${subreddit}?sort=${sortQuery}&view=compact` onclick=`setPref('view', 'compact')` id=`pref_view_compact`) compact
+              a(href=`${currentPath}?sort=${sortQuery}&view=compact` onclick=`setPref('view', 'compact')` id=`pref_view_compact`) compact
 
       if posts
         each child in posts.posts
@@ -93,4 +88,5 @@ html
             if posts.after
               div.footer-item
                 - var newQuery = {...query, after: posts.after}
-                a(href=`/r/${subreddit}?${encodeQueryParams(newQuery)}`) next ⟶
+                a(href=`${currentPath}?${encodeQueryParams(newQuery)}`) next 
+                  nobr ->


### PR DESCRIPTION
`Track Session Views` preference graduates from experimental.
Extracted `index` render code into a separate function, allowing for routes such as `/`, `/home`, `/m/xxx`, etc. to render correctly while retaining their URLs in the browser.
Other minor fixes include:
* Support SQLite foriegn keys correctly
* Follow best practices on SQLite optimization
* Tweak `Track Session Views` database tables and code for further performance and reliability gains
* Fix subreddit `about` text not being HTML decoded correctly.
* Removed Track Session Views performance info from footer
* Standardized CSS `warning` to `caution`