### PR TITLE
[Enhancement] External Link Expansion

### DIFF
--- a/src/extlinks.js
+++ b/src/extlinks.js
@@ -1,11 +1,11 @@
 class ExtLinks {
     static ExternalDomains = [
-        {
+        { // XKCD
             expression: `xkcd\\.com`,
             should_fetch: true,
-            fetch_transform: ((post) => post.url),
-            function: function(url, data) {
-                const returnData = {};
+            post_only: false,
+            fetch_transform: ((url) => url),
+            link_data: function(url, data) {
                 // The image is located in the #comic div and is in the format "//imgs.xkcd.com/comics/.*?"
                 const expression = /<div id=\"comic\">.*?<img src=\"(.*?imgs\.xkcd\.com\/comics\/.*?)\".*?\/>/gis;
                 const matches = [...data.matchAll(expression)];
@@ -13,19 +13,34 @@ class ExtLinks {
                 // We only care about the first match
                 // and index 1 for the capture group
                 if (matches[0] && matches[0][1]) {
+                    return "https:" + matches[0][1];
+                }
+
+                return null;
+            },
+            post_data: function(url, data) {
+                const returnData = {};
+                
+                if (url) {
                     returnData.post_hint = "image";
-                    returnData.url = "https:" + matches[0][1];
+                    returnData.url = url;
                     returnData.thumbnail = returnData.url;
                     return returnData;
                 }
                 return null;
             },
+            inline_replacement: ((url) => `<a href="${url}"><img class="inline" src="${url}"></a>`),
         },
-        {
-            expression: `imgur\\.com`,
+        { // Generic imgur/reddit links
+            // imgur.com, preview.reddi.it, i.redd.it, v.redd.it
+            expression: `(?:imgur\\.com|(?:preview|[iv])\\.redd\\.it|imgs\\.xkcd\\.com)`,
             should_fetch: false,
-            fetch_transform: ((post) => post.url),
-            function: function(url, data) {
+            post_only: false,
+            fetch_transform: ((url) => url),
+            link_data: function(url, data) {
+                return url;
+            },
+            post_data: function(url, data) {
                 const returnData = {};
                 returnData.url = url;
                 const expression = /(?:gifv|mp4)/i;
@@ -37,6 +52,7 @@ class ExtLinks {
                         returnData.secure_media.reddit_video.hls_url = 
                             url.replace(expression, 'mp4');
                     returnData.thumbnail = returnData.url;
+                    returnData.preview = { images: [ { source: { url: returnData.thumbnail }}]};
                     returnData.post_hint = "hosted:video";
                 } else {
                     // Probably just a normal image
@@ -44,36 +60,85 @@ class ExtLinks {
                 }
                 return returnData;
             },
+            inline_replacement: function(url) {
+                const expression = /(?:gifv|mp4)/i;
+                const gifExpression = /gifv/i;
+                if (url.match(expression)) {
+                    // Probably a gif / video
+                    // If it's a gifv, enable autoplay
+                    return `<video controls muted data-dashjs-player preload="metadata" poster="${url}"${url.match(gifExpression) ? "autoplay" : ""}><source src="${url}"></video>`;
+                } else {
+                    // Probably just a normal image
+                    return `<a href="${url}"><img class="inline" src="${url}"></a>`;
+                }
+            },
         },
-        {
+        { // Old-style imgur gallery
             expression: `imgur\\.com\/a\/`,
             should_fetch: true,
-            fetch_transform: ((post) => post.url.includes("/gallery") ? post.url : post.url + "/embed"),
-            function: function(url, data) {
+            post_only: true,
+            fetch_transform: ((url) => url.includes("/gallery") ? url : url + "/embed"),
+            link_data: function(url, data) {
+                return url;
+            },
+            post_data: function(url, data) {
                 const returnData = {};
                 returnData.url = url;
                 const expression = /^\s+?images\s+?:\s+?(\{\"count\":\d+?,\"images\":\[\{.*\},?\]\})/gm;
-                data.matchAll(expression).forEach((match) => {
-                    // Build a gallery with these images
-                    returnData.is_gallery = true;
-                    returnData.gallery_data = {
-                        items: [],
-                    };
-                    JSON.parse(match[1]).images.map((img) => {
-                        returnData.gallery_data.items.push({
-                            media_id: "https://i.imgur.com/" + img.hash + ".jpg",
+                const matches = data.matchAll(expression);
+                if (matches) {
+                    const matchArray = Array.from(matches);
+                    if (matchArray.length == 1) {
+                        // Single-item, don't treat it as a gallery
+                        const video_expression = /(?:gifv|mp4)/i;
+                        JSON.parse(matchArray[0][1]).images.map((img) => {
+                            if (img.ext.match(video_expression)) {
+                                // Probably a gif / video
+                                returnData.secure_media = { reddit_video: {} };
+                                returnData.secure_media.reddit_video.fallback_url = 
+                                    returnData.secure_media.reddit_video.dash_url = 
+                                    returnData.secure_media.reddit_video.hls_url = 
+                                        "https://i.imgur.com/" + img.hash + img.ext;
+                                returnData.thumbnail = "https://i.imgur.com/" + img.hash + ".jpg";
+                                returnData.preview = { images: [ { source: { url: returnData.thumbnail }}]};
+                                returnData.post_hint = "hosted:video";
+                            } else {
+                                // Probably just a normal image
+                                returnData.post_hint = "image";
+                                returnData.url = "https://i.imgur.com/" + img.hash + ".jpg";
+                            }
                         });
-                    });
-                });
+                    } else {
+                        // Build a gallery with these images
+                        returnData.is_gallery = true;
+                        returnData.gallery_data = {
+                            items: [],
+                        };
+                        matchArray.forEach((match) => {
+                            JSON.parse(match[1]).images.map((img) => {
+                                returnData.gallery_data.items.push({
+                                    media_id: "https://i.imgur.com/" + img.hash + ".jpg",
+                                });
+                            });
+                        });
+                    }
+                }
                 
                 return returnData;
             },
+            inline_replacement: function(url) {
+                return null;
+            },
         },
-        {
+        { // New-style imgur gallery
             expression: `imgur\\.com\/gallery\/`,
             should_fetch: true,
-            fetch_transform: ((post) => post.url),
-            function: function(url, data) {
+            post_only: true,
+            fetch_transform: ((url) => url),
+            link_data: function(url, data) {
+                return url;
+            },
+            post_data: function(url, data) {
                 const returnData = {};
                 returnData.url = url;
                 const expression = /http.{1,2}\/\/i\.imgur\.com\/\w+\.jpeg/g;
@@ -89,6 +154,9 @@ class ExtLinks {
                 });
 
                 return returnData;
+            },
+            inline_replacement: function(url) {
+                return null;
             },
         },
     ];
@@ -115,38 +183,118 @@ class ExtLinks {
 			.catch((err) => null);
     }
 
-    static async parseExternal(post) {
-        const domain = ExtLinks.getExternalDomain(post.url);
+    static async parseExternalLink(url) {
+        const domain = ExtLinks.getExternalDomain(url);
         if (domain) {
+            var fetch_data = null;
             if (domain.should_fetch) {
-                const data = await ExtLinks.fetchExternal(domain.fetch_transform(post));
+                fetch_data = await ExtLinks.fetchExternal(domain.fetch_transform(url));
+            }
+            
+            return domain.link_data(url, fetch_data);
+        }
 
-                if (data) {
-                    const result = domain.function(post.url, data);
-                    return result;
+        return null;
+    }
+
+    static async parseExternalInlineLink(url) {
+        const domain = ExtLinks.getExternalDomain(url);
+        if (domain && !domain.post_only) {
+            var fetch_data = null;
+            if (domain.should_fetch) {
+                fetch_data = await ExtLinks.fetchExternal(domain.fetch_transform(url));
+            }
+
+            const link_data = domain.link_data(url, fetch_data);
+            const inline_replacement = domain.inline_replacement(link_data);
+            return inline_replacement;
+        }
+
+        return null;
+    }
+
+    static async parseExternalPost(post) {
+        if (post.url) {
+            const domain = ExtLinks.getExternalDomain(post.url);
+            if (domain) {
+                const link_data = await ExtLinks.parseExternalLink(post.url);
+                if (link_data) {
+                    var fetch_data = null;
+
+                    if (domain.post_only) {
+                        if (domain.should_fetch) {
+                            fetch_data = await ExtLinks.fetchExternal(domain.fetch_transform(post.url));
+                        }
+                        else {
+                            fetch_data = post.secure_media_embed;
+                        }
+                    }
+
+                    return domain.post_data(link_data, fetch_data);
                 }
-            } else {
-                const result = domain.function(post.url, post.secure_media_embed);
-                return result;
             }
         }
 
         return null;
     }
 
+    static async resolveExternalInlineLinks(html) {
+        const expression = /<a href="(http[s]?:\/\/.*?)">\1?<\/a>/g;
+        const matches = Array.from(html.matchAll(expression));
+
+        var result = html;
+        for (var i = 0; i < matches.length; i++) {
+            const match = matches[i];
+            const replacement = await ExtLinks.parseExternalInlineLink(match[1]);
+            if (replacement) {
+                result = result.replace(match[0], replacement);
+            }
+        }
+
+        return result;
+    }
+
     static async resolveExternalLinks(post) {
-        if (post.url) {
-            const data = await ExtLinks.parseExternal(post);
+        // First, check for a link post
+        if (post.post_hint == 'link') {
+            const data = await ExtLinks.parseExternalPost(post);
             if (data) {
                 return data;
             }
-        } 
-        return null;
-    }
+        }
 
-    static updatePost(post, data) {
-        // Update the post approrpriately
-        post = Object.assign(post, data);
+        // Otherwise, if the first thing in this self post is a link, or it's only a link or a group of links, treat it as a link post
+        // Easier to perform the regex on the markdown instead of the HTML version
+        if (post.selftext) {
+            const expression = /^\[(.*?)\]\(\1?\)/g;
+            const matches = Array.from(post.selftext.matchAll(expression));
+
+            if (matches.length > 0) {
+                // Treat this as a link post with the first match
+                post.post_hint = 'link';
+                post.url = matches[0][1];
+                const data = await ExtLinks.parseExternalPost(post);
+                if (data) {
+                    // Strip out the matching link from the self text
+                    data.selftext = post.selftext.replace(`[${post.url}](${post.url})`, '');
+                    const expr = new RegExp(`(<|&lt;)a href="${post.url}"(>|&gt;)${post.url}(<|&lt;)/a(>|&gt;)`, "g")
+                    data.selftext_html = post.selftext_html.replace(expr, '');
+                }
+
+                return data;
+            }
+        }
+
+        // Finally, find all anchors that href to known domains and contain just a link to the same href
+        if (post.selftext_html) {
+            const result = await ExtLinks.resolveExternalInlineLinks(post.selftext_html);
+
+            if (result) {
+                return { selftext_html: result };
+            }
+        }
+
+        return null;
     }
 }
 

--- a/src/mixins/comment.pug
+++ b/src/mixins/comment.pug
@@ -52,7 +52,7 @@ mixin comment(com, isfirst, parent_id, next_id, prev_id)
         summary.expand-comments
           +infoContainer(data, next_id, prev_id)
         div.comment-body
-          != convertInlineImageLinks(data.body_html)
+          != data.body_html
         if hasReplyData
           div.replies
             - var total = data.replies.data.children.length

--- a/src/mixins/post.pug
+++ b/src/mixins/post.pug
@@ -34,7 +34,7 @@ mixin post(p, currentUrl)
                   h2
                     != p.over_18 ? 'nsfw' : 'spoiler'
               div.self-text.card
-                != convertInlineImageLinks(p.selftext_html)
+                != p.selftext_html
         if prefs.view != "card"
           div.media-preview(class=`${p.is_crosspost ? "crosspost" : ""}`)
             - var onclick = `toggleDetails('${p.id}')`

--- a/src/mixins/postUtils.pug
+++ b/src/mixins/postUtils.pug
@@ -60,27 +60,6 @@
     }
   }
 -
-  function convertInlineImageLinks(html) {
-    // Find all anchors that href to preview.redd.it, i/v.redd.it, i.imgur.com
-    // and contain just a link to the same href
-    const expression = /<a href="(http[s]?:\/\/(?:preview\.redd\.it|[iv]\.redd\.it|i\.imgur\.com).*?)">\1?<\/a>/g;
-    const matches = Array.from(html.matchAll(expression));
-    var result = html;
-    matches.forEach((match) => {
-      // Imgur gifv is just an MP4 video with no sound
-      // v.redd.it is a video
-      if (match[1].match(/(?:gifv|mp4|v\.reddi\.it)/i)) {
-        // Replace each occurrence with a video tag
-        result = result.replace(match[0], '<video controls muted data-dashjs-player preload="metadata" poster="' + match[1] + '"><source src="' + match[1] + '"></video>');
-      } else {
-        // Replace each occurrence with an actual img tag
-        result = result.replace(match[0], '<a href="' + match[1] + '"><img class="inline" src="' + match[1] + '"></a>');
-      }
-    })
-
-    return result;
-  }
--
   function decodePostVideoUrls(p) {
     // Video and poster URLs can be HTML-encoded, so decode them.
     const he = require_he;

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -521,7 +521,7 @@ form {
   .image-viewer img,
   .image-viewer video
   {
-    max-height: 35vh;
+    max-height: 45vh;
   }
   .media-preview a {
     font-size: 2rem;

--- a/src/views/comments.pug
+++ b/src/views/comments.pug
@@ -61,8 +61,8 @@ html
             a(href=`/media/${post.url}`)
               img(src=post.url).post-media
           else if isPostVideo(post)
-            - var url = post.secure_media.reddit_video.dash_url
-            video(controls data-dashjs-player src=`${url}`).post-media
+            - var decodedVideos = decodePostVideoUrls(post)
+            video(data-dashjs-player="" playsinline="" controls="" muted="" preload="metadata" src=decodedVideos[1] poster=decodedVideos[4]).post-media
           else if isPostLink(post)
             a(href=post.url)
               | #{post.domain} ↗

--- a/src/views/comments.pug
+++ b/src/views/comments.pug
@@ -69,7 +69,7 @@ html
 
         if post.selftext_html
           div.self-text
-            != convertInlineImageLinks(post.selftext_html)
+            != post.selftext_html
 
         hr
 


### PR DESCRIPTION
Consolidates multiple external link handlers into the single `ExtLinks` class, enabling greater consistency in link handling.

Enhancements:
* Deprecate `convertInlineImageLinks`, replace with `ExtLinks.resolveInlineLinks` to conslidate code
* Add `*.redd.it`, `imgs.xkcd.com` to ExtLinks domains
* Properly handle imgur video/gifv within galleries
* Treat selftext posts with just a link as a "link" post, and attempt to expand that link if possible
* Adjust image preview height for medium-size screens.

Fixes:
* Inconsistent video and poster rendering between `index` and `comments` views.