### PR TITLE
v2.5.1 — security hardening, bug fixes, dependency pinning, workflow cleanup

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -25,10 +25,6 @@ jobs:
           PLATFORMS=linux/amd64,linux/arm64
           REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
 
-          if [[ $GITHUB_REF == refs/heads/dev ]] then
-            VERSION=dev
-          fi
-
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:latest
+FROM oven/bun:1
 ADD ./ ./
 RUN mkdir -p /data
 WORKDIR /data

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"module": "index.ts",
 	"type": "module",
 	"devDependencies": {
-		"@types/bun": "latest",
+		"@types/bun": "^1.3.0",
 		"pug-cli": "^1.0.0-alpha6"
 	},
 	"peerDependencies": {

--- a/src/auth.js
+++ b/src/auth.js
@@ -55,7 +55,7 @@ function authenticateAdmin(req, res, next) {
 			res.status(400).send("only admins can invite");
 		}
 	} catch (error) {
-		res.send(`failed to authenticate as admin: ${error}`);
+		res.status(403).send("failed to authenticate as admin");
 	}
 }
 

--- a/src/db.js
+++ b/src/db.js
@@ -161,7 +161,7 @@ runMigration("lazy-delete-sessions", () => {
   // Remove the UNIQUE constraint from `sessions`
   // Add FK with cascade delete to `views`
   db.run(`
-    PRAGMA foriegn_keys=off;
+    PRAGMA foreign_keys=off;
     
     BEGIN TRANSACTION;
 
@@ -199,7 +199,7 @@ runMigration("lazy-delete-sessions", () => {
 
     COMMIT;
 
-    PRAGMA foriegn_keys=on;
+    PRAGMA foreign_keys=on;
   `);
 });
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -67,7 +67,7 @@ router.get("/comments/:id", authenticateToken, async (req, res) => {
 	const params = {
 		limit: 50,
 	};
-	response = await G.getSubmissionComments(id, params);
+	const response = await G.getSubmissionComments(id, params);
 	const prefs = get_user_prefs(req.user.id);
 
 	const data = unescape_submission(response);
@@ -107,7 +107,7 @@ router.get(
 		const params = {
 			limit: 50,
 		};
-		response = await G.getSingleCommentThread(parent_id, child_id, params);
+		const response = await G.getSingleCommentThread(parent_id, child_id, params);
 		const prefs = get_user_prefs(req.user.id);
 		const comments = response.comments;
 
@@ -402,7 +402,7 @@ router.get("/create-invite", authenticateAdmin, async (req, res) => {
 	}
 });
 
-router.get("/delete-invite/:id", authenticateToken, async (req, res) => {
+router.get("/delete-invite/:id", authenticateAdmin, async (req, res) => {
 	try {
 		db.run("DELETE FROM invites WHERE id = $id", { id: req.params.id });
 		return res.redirect(`/dashboard`);
@@ -505,7 +505,7 @@ router.post("/login", async (req, res) => {
 				httpOnly: true,
 				maxAge: 5 * 24 * 60 * 60 * 1000,
 			})
-			.redirect(req.query.redirect || "/");
+			.redirect(req.query.redirect && req.query.redirect.startsWith("/") && !req.query.redirect.startsWith("//") ? req.query.redirect : "/");
 	} else {
 		res.render("login", {
 			message: "invalid credentials, try again",
@@ -563,14 +563,16 @@ router.post("/unsubscribe", authenticateToken, async (req, res) => {
 router.post("/set-pref", authenticateToken, async (req, res) => {
 	const { preference, value} = req.body;
 	const user = req.user;
-	const validPrefs = ['sort', 'view', 'collapseAutoMod', 'trackSessions']
-	
-	if (validPrefs.includes(preference)) {
-		var query = `
-			UPDATE users
-			SET pref_${preference} = $value
-			WHERE id = $user_id
-		`;
+	const prefToColumn = {
+		sort: 'pref_sort',
+		view: 'pref_view',
+		collapseAutoMod: 'pref_collapseAutomod',
+		trackSessions: 'pref_trackSessions',
+	};
+	const column = prefToColumn[preference];
+
+	if (column) {
+		const query = `UPDATE users SET ${column} = $value WHERE id = $user_id`;
 		await db.query(query).run({ user_id: user.id, value: value });
 		res.status(200).send("Updated successfully");
 	}

--- a/src/views/dashboard.pug
+++ b/src/views/dashboard.pug
@@ -133,7 +133,7 @@ html
                   td #{user_row.isAdmin ? 'yes' : 'no'}
                   td 
                     if user.id !== user_row.id && users.length > 1
-                      a(href=`/delete-user/${user.id}` onclick=`areYouSure(event, 'user', '${user.username}')`) delete
+                      a(href=`/delete-user/${user_row.id}` onclick=`areYouSure(event, 'user', '${user_row.username}')`) delete
                     else
                       | current user
 


### PR DESCRIPTION
Patch release rolling up [PR #20](https://github.com/PortableProgrammer/lurker/pull/20) plus the GitHub-Flow workflow cleanup.

This is also the **final `dev` → `main` PR**. After merge and tagging, `dev` will be deleted and future feature branches will be cut from `main` directly.

## Security

- **SQL injection** — `set-pref` route hardened via static column lookup map; was previously interpolating user-controlled column names.
- **Authorization tightening** — `delete-invite` upgraded from `authenticateToken` to admin-only.
- **Open redirect** — login `redirect` parameter now validated as a relative path before use.
- **Error-detail leak** — `authenticateAdmin` catch block no longer surfaces internal error specifics.

## Bug fixes

- **Dashboard delete-user link** was passing the *current* user's id/username instead of the target row's — data-loss-class bug.
- **Implicit global** — missing `const` on `response` in `comments` and `single-comment-thread` routes.
- **`PRAGMA foriegn_keys` typo** in lazy-delete-sessions migration — SQLite silently ignored it, so FK enforcement wasn't actually active during that migration.

## Dependencies

- `@types/bun`: `latest` → `^1.3.0`
- Dockerfile base: `oven/bun:latest` → `oven/bun:1`

## CI / branch model

- Removed dead `dev` branch logic from `publish-docker.yml` (also fixed a latent `if [[ ... ]] then` bash syntax error in the removed block).
- After this release, the workflow only meaningfully responds to `main` pushes and `v*` tags.

## Verification

- 6 source files changed (+20/-18) for the code work
- 1 workflow file changed (-4) for the CI cleanup
- All four security fixes are surface-narrowing — no behavior change for legitimate users
- Foreign-key PRAGMA fix takes effect on next DB migration; the wiped SQLite is being rebuilt anyway